### PR TITLE
fixed: replace() will destroy original args.

### DIFF
--- a/lib/atom-user-commands.js
+++ b/lib/atom-user-commands.js
@@ -96,9 +96,31 @@
 		}
 	}
 
+	// Clear de bottom panel
+	function clearConsole() {
+		if (commands.panel) {
+			while (commands.panel.item.lastChild) {
+				var child = commands.panel.item.lastChild;
+				commands.panel.item.removeChild(child);
+			}			
+		}
+	}
+	
+	// Output to de bottom panel
+	function writeConsole( text, style ) {
+		var div = commands.panel.item;
+		var line = window.document.createElement( 'div' );
+		line.classList.add( style );
+		line.textContent = text;
+		div.appendChild( line );
+		div.scrollTop = div.scrollHeight;		
+	}
+	
 	// Execute an OS command
 	function execute( command, args, options ) {
-
+		
+		clearConsole();
+		
 		// Open the panel if it is not
 		if ( !commands.panel ) {
 			showConsole();
@@ -110,11 +132,14 @@
 			commands.subscriptions.remove(commands.closeConsoleDisposable);
 		}
 
+		//writeConsole('? ' + JSON.stringify(args), 'echo');
+		
 		var env = getEnv();
-
-		command = replace( command || '', env );
-		args = replace( args || [], env );
-		options = replace( options || {}, env );
+		var command = replace( command || '', env );
+		var args = replace( args || [], env );
+		var options = replace( options || {}, env );
+		//writeConsole('? ' + JSON.stringify(args), 'echo');	
+		//writeConsole("> " + JSON.stringify( env), "echo");
 
 		// Announcing launch
 		commands.panel.item.appendChild( window.document.createElement( 'br' ) );
@@ -123,36 +148,24 @@
 		span.textContent = "> " + command + ' ' + JSON.stringify( args ) + ' ' + JSON.stringify( options );
 		commands.panel.item.appendChild( span );
 		commands.panel.item.appendChild( window.document.createElement( 'br' ) );
-		commands.panel.item.appendChild( window.document.createElement( 'br' ) );
+		//commands.panel.item.appendChild( window.document.createElement( 'br' ) );
 
 		// Run the spawn, we pass args.slice() to make a shallow copy of the array because spawn will modify it.
 		var proc = spawn( command, args.slice(), options );
 
 		// Update console panel on data
 		proc.stdout.on( 'data', function( data ) {
-
-			var div = commands.panel.item;
-			var line = window.document.createElement( 'div' );
-			line.classList.add( 'stdout' );
-			line.textContent = data.toString();
-			div.appendChild( line );
-			div.scrollTop = div.scrollHeight;
-
+			writeConsole(data.toString(), 'stdout');
 		} );
 
 		// Update console panel on error data
 		proc.stderr.on( 'data', function( data ) {
-
-			var div = commands.panel.item;
-			var line = window.document.createElement( 'div' );
-			line.classList.add( 'stderr' );
-			line.textContent = data.toString();
-			div.appendChild( line );
-			div.scrollTop = div.scrollHeight;
+			writeConsole(data.toString(), 'stderr');
 		} );
 
 		proc.stdout.on( 'close', function( code, signal ) {
 			// console.info('command closed', code, signal);
+			writeConsole('[Finished]', 'stdout');
 		} );
 
 		// Register code for termination
@@ -173,12 +186,13 @@
 	function buildPanel() {
 
 		var mainDiv = window.document.createElement( 'div' );
-		mainDiv.classList.add( 'atom-user-commands-console' );
-
-		//var input = window.document.createElement( 'textarea' );
-		//input.classList.add( 'console-input' );
-		//mainDiv.appendChild(input);
-
+		if (true) {
+			mainDiv.classList.add( 'atom-user-commands-console' );
+		}	else {
+			var input = window.document.createElement( 'textarea' );
+		  input.classList.add( 'console-input' );
+			mainDiv.appendChild(input);
+		}
 		return mainDiv;
 
 	}
@@ -237,24 +251,21 @@
 
 	// Replace array string elements with variables
 	function replaceArray( input, vars ) {
-
+		var output = new Array(input.length);	
 		for ( var i = 0; i < input.length; i++ ) {
-			input[ i ] = replace( input[ i ], vars );
+			output[ i ] = replace( input[ i ], vars );
 		}
-
-		return input;
-
+		return output;
 	}
 
 	// Replaces oboject string members with variables
 	function replaceObject( input, vars ) {
-
+		var output = {};
 		var keys = Object.keys( input );
 		keys.forEach( function( key ) {
-			input[ key ] = replace( input[ key ], vars );
+			output[ key ] = replace( input[ key ], vars );
 		} );
-
-		return input;
+		return output;
 	}
 
 	// TODO: Register active processes for killing;

--- a/lib/atom-user-commands.js
+++ b/lib/atom-user-commands.js
@@ -150,6 +150,9 @@
 		commands.panel.item.appendChild( window.document.createElement( 'br' ) );
 		//commands.panel.item.appendChild( window.document.createElement( 'br' ) );
 
+		// record time
+		var millisec = (new Date()).getTime();
+		
 		// Run the spawn, we pass args.slice() to make a shallow copy of the array because spawn will modify it.
 		var proc = spawn( command, args.slice(), options );
 
@@ -165,7 +168,9 @@
 
 		proc.stdout.on( 'close', function( code, signal ) {
 			// console.info('command closed', code, signal);
-			writeConsole('[Finished]', 'stdout');
+			var current = (new Date()).getTime();
+			var delta = (current - millisec) * 0.001;
+			writeConsole('[Finished in ' + delta.toString() + ' seconds]', 'stdout');
 		} );
 
 		// Register code for termination


### PR DESCRIPTION
1. replace() will destroy original command/args, the original args contains '{path}' '{absPath}' will be replaced into the real file name forever. change active file in atom will not make args update.
2. clear the bottom panel before  each execution. text in the bottom panel will never get cleared. some C++ template compiler error could exceed 1k lines which make it hard to review and slow down ATOM after several executions.
3. After finished, output the time of how long the commands has been executed.
